### PR TITLE
Remove wrapper components, and simplify the Lumino component.

### DIFF
--- a/src/components/Lumino.vue
+++ b/src/components/Lumino.vue
@@ -61,7 +61,8 @@ export default {
       // create a box panel, which holds the dock panel, and controls its layout
       main: new BoxPanel({ direction: 'left-to-right', spacing: 0 }),
       // create dock panel, which holds the widgets
-      dock: new DockPanel()
+      dock: new DockPanel(),
+      widgets: []
     }
   },
 
@@ -79,6 +80,20 @@ export default {
     this.$nextTick(() => {
       Widget.attach(vm.main, vm.$refs.main)
     })
+  },
+
+  updated () {
+    this.$children
+      .filter(child => !this.widgets.includes(child._uid))
+      .forEach(newChild => {
+        this.widgets.push(newChild._uid)
+        const id = `${newChild.$options.name}-${new Date().getTime()}`
+        const name = newChild.$options.name
+        this.addWidget(id, name)
+        this.$nextTick(() => {
+          document.getElementById(id).appendChild(newChild.$el)
+        })
+      })
   },
 
   methods: {

--- a/src/components/Lumino.vue
+++ b/src/components/Lumino.vue
@@ -96,7 +96,7 @@ export default {
 
 <style lang="scss">
 $body-font-family: 'Roboto, Ubuntu, Arial, Verdana, sans-serif';
-$font-size-root: 14px;
+$font-size-root: 16px;
 #workflow-panel {
   #main {
     display: flex;

--- a/src/components/Lumino.vue
+++ b/src/components/Lumino.vue
@@ -18,45 +18,40 @@
     <div id="workflow-panel">
       <div ref="main" id="main" class="pa-4 fill-height"></div>
       <div v-show="false">
-        <!-- in this hidden area, you need to create your component wrappers. The LuminoWidget will be inserted
-             in the div above, but the code will `appendChild` each component to a new widget. -->
-        <VueComponentWrapper
-            v-for="widget of this.widgets"
-            :key="widget.id"
-            :widget="widget">
-          <component
-            :is="widget.is"
-            v-bind="widget.propsData"
-          />
-        </VueComponentWrapper>
+        <slot></slot>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { LuminoWidget, VueComponentWrapper } from '@/components/lumino-widget'
+import LuminoWidget from '@/components/lumino-widget'
 import { BoxPanel, DockPanel, Widget } from '@lumino/widgets'
 
 import '@lumino/default-theme/style/index.css';
 
 /**
- * This component is the example of how the LuminoWidget and the VueComponentWrapper
- * together in your application. You can call this component whatever you like,
- * use more events, or customize more how you use Lumino in your application.
+ * A component to wrap the Lumino application.
+ *
+ * It will create a BoxPanel (left to right, no gutters) with a dock
+ * panel. Each component created in the default slot will be added
+ * to an invisible area.
+ *
+ * Upon creation, the component will take care to transfer the $el
+ * of each children component to the Lumino widget div, creating the
+ * impression that the component was created inside the tab/widget.
+ *
+ * Lumino uses DOM, and Vue the VDOM. So this is an approach that
+ * works, but there could be alternative approaches too. Feel free
+ * to adapt it to your use case as necessary.
+ *
+ * @since 0.2
  */
 export default {
   /**
    * Show a useful name in logs/debug/vue-extension
    */
   name: 'Lumino',
-
-  /**
-   * Components used by the Lumino component
-   */
-  components: {
-    VueComponentWrapper
-  },
 
   /**
    * Data for the Lumino component
@@ -66,9 +61,7 @@ export default {
       // create a box panel, which holds the dock panel, and controls its layout
       main: new BoxPanel({ direction: 'left-to-right', spacing: 0 }),
       // create dock panel, which holds the widgets
-      dock: new DockPanel(),
-      // holds a list of widgets added to the UI
-      widgets: []
+      dock: new DockPanel()
     }
   },
 
@@ -91,18 +84,11 @@ export default {
   methods: {
     /**
      * Create a widget.
-     * @param {{
-     *   id: string,
-     *   name: string,
-     *   closable: [null|boolean],
-     *   propsData: [null|Object],
-     *   is: Class
-     * }} widget - widget
+     *
      */
-    addWidget(widget) {
-      const luminoWidget = new LuminoWidget(widget)
+    addWidget(id, name) {
+      const luminoWidget = new LuminoWidget(id, name, /* closable */ true)
       this.dock.addWidget(luminoWidget)
-      this.widgets.push(widget)
     }
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -21,9 +21,19 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
      when the button is clicked) -->
 <template>
   <div>
-    <button @click="onAddHomeButtonClicked">Add Home</button>
-    <button @click="onAddCircleButtonClicked">Add Circle</button>
-    <Lumino ref="lumino" />
+    <button @click="addHelloWorldWidget">Add Hello World</button>
+    <button @click="addColoredCircleWidget">Add Circle</button>
+    <Lumino ref="lumino">
+      <HelloWorld
+        v-for="helloWorldWidget of this.helloWorldWidgets"
+        :key="helloWorldWidget.id"
+      ></HelloWorld>
+      <ColoredCircle
+        v-for="coloredCircleWidget of this.coloredCircleWidgets"
+        :key="coloredCircleWidget.id"
+        :color="_getRandomColor()"
+      ></ColoredCircle>
+    </Lumino>
   </div>
 </template>
 
@@ -45,12 +55,17 @@ export default {
 
   components: {
     Lumino,
-    // It is important to declare the components here, or globally, so that when the Lumino component declares
-    // <component :is=widget.is />, it is loaded correctly.
-    // eslint-disable-next-line vue/no-unused-components
+    // components used as example
     HelloWorld,
-    // eslint-disable-next-line vue/no-unused-components
     ColoredCircle
+  },
+
+  data () {
+    return {
+      helloWorldWidgets: [],
+      coloredCircleWidgets: [],
+      colors: ['purple', 'green', 'blue', 'red']
+    }
   },
 
   /**
@@ -61,13 +76,7 @@ export default {
    */
   mounted () {
     this.$nextTick(() => {
-      const id = 'hello-world-pre-added-component-1'
-      this.$refs.lumino.addWidget({
-        // unique ID
-        id,
-        name: id,
-        is: HelloWorld
-      })
+      this.addHelloWorldWidget()
     })
   },
 
@@ -76,30 +85,28 @@ export default {
    */
   methods: {
     /**
-     * Showing how one can add widgets reacting to events such as a button click.
+     * Add a `HelloWorld` widget.
      */
-    onAddHomeButtonClicked () {
-      const id = `${Math.random()}`
-      const widget = {
-        id,
-        name: `hello-${id}`,
-        is: HelloWorld
-      }
-      this.$refs.lumino.addWidget(widget)
+    addHelloWorldWidget () {
+      const id = `${HelloWorld.name}-${Math.random()}`
+      const name = `${HelloWorld.name}`
+      this.$refs.lumino.addWidget(id, name)
     },
-    onAddCircleButtonClicked () {
-      const id = `${Math.random()}`
-      const colors = ['purple', 'green', 'blue', 'red']
-      const color = colors[Math.floor(Math.random() * colors.length)]
-      const widget = {
-        id,
-        name: `circle-${id}`,
-        is: ColoredCircle,
-        propsData: {
-          color
-        }
-      }
-      this.$refs.lumino.addWidget(widget)
+    /**
+     * Add a `ColoredCircle` widget.
+     */
+    addColoredCircleWidget () {
+      const id = `${ColoredCircle.name}-${Math.random()}`
+      const name = `${ColoredCircle.name}`
+      this.$refs.lumino.addWidget(id, name)
+    },
+    /**
+     * Get a random color to be used as prop for the `ColoredCircle` widget.
+     * @returns {string} a random color member of `this.colors`
+     * @private
+     */
+    _getRandomColor () {
+      return this.colors[Math.floor(Math.random() * this.colors.length)]
     }
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -22,12 +22,15 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
 <template>
   <div>
     <button
-      @click="helloWorldWidgets.push(new Date().getTime())"
+      @click="onAddHelloWorldButtonClicked"
       >Add Hello World</button>
     <button
-      @click="coloredCircleWidgets.push(new Date().getTime())"
+      @click="onAddColoredCircleButtonClicked"
       >Add Circle</button>
-    <Lumino ref="lumino">
+    <Lumino ref="lumino"
+      v-on:lumino:deleted="onWidgetDeletedEvent"
+      v-on:lumino:activated="onWidgetActivatedEvent"
+    >
       <!-- In this example we are adding two types of elements as tabs. The code
       of this view is using the component name plus a random number for the component
       ID, and the component name as the name to be displayed in the Lumino tab.
@@ -38,13 +41,15 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
       events tries to keep everything in-sync (fingers-crossed).
       -->
       <HelloWorld
-        v-for="helloWorldWidget of this.helloWorldWidgets"
-        :key="helloWorldWidget"
+        v-for="id of this.helloWorldWidgets"
+        :key="id"
+        :id="id"
       ></HelloWorld>
       <ColoredCircle
-        v-for="coloredCircleWidget of this.coloredCircleWidgets"
-        :key="coloredCircleWidget"
-        :color="_getRandomColor()"
+        v-for="id of this.coloredCircleWidgets"
+        :key="id"
+        :id="id"
+        :color="'red'"
       ></ColoredCircle>
     </Lumino>
   </div>
@@ -56,6 +61,8 @@ import Lumino from '@/components/Lumino'
 // importing the components we want to display within the Lumino component
 import HelloWorld from '@/components/example/HelloWorld'
 import ColoredCircle from '@/components/example/ColoredCircle'
+// to set reactive value
+import Vue from 'vue'
 
 /**
  * An example view, showing how to use the Lumino component. Not exported, not for external use, for
@@ -75,12 +82,36 @@ export default {
 
   data () {
     return {
-      // list of `HelloWorld` widgets
-      helloWorldWidgets: [],
-      // list of `ColoredCircle` widgets
-      coloredCircleWidgets: [],
-      // colors used in the `ColoredCircle` widget, we pick only one randomly
-      colors: ['purple', 'green', 'blue', 'red']
+      // the widgets added to the view
+      /**
+       * @type {
+       *   Object.<string, string>
+       * }
+       */
+      widgets: {},
+      helloWorldType: HelloWorld.name,
+      coloredCircleType: ColoredCircle.name
+    }
+  },
+
+  computed: {
+    helloWorldWidgets () {
+      const widgets = []
+      for (const [id, type] of Object.entries(this.widgets)) {
+        if (type === HelloWorld.name) {
+          widgets.push(id)
+        }
+      }
+      return widgets
+    },
+    coloredCircleWidgets () {
+      const widgets = []
+      for (const [id, type] of Object.entries(this.widgets)) {
+        if (type === ColoredCircle.name) {
+          widgets.push(id)
+        }
+      }
+      return widgets
     }
   },
 
@@ -92,7 +123,7 @@ export default {
    */
   mounted () {
     this.$nextTick(() => {
-      this.helloWorldWidgets.push(new Date().getTime())
+      this.onAddHelloWorldButtonClicked()
     })
   },
 
@@ -100,13 +131,26 @@ export default {
    * Example methods.
    */
   methods: {
-    /**
-     * Get a random color to be used as prop for the `ColoredCircle` widget.
-     * @returns {string} a random color member of `this.colors`
-     * @private
-     */
-    _getRandomColor () {
-      return this.colors[Math.floor(Math.random() * this.colors.length)]
+    onAddHelloWorldButtonClicked () {
+      const id = `${new Date().getTime()}`
+      // eslint-disable-next-line no-console
+      console.log(`Adding new widget ${ColoredCircle.name}, ID ${id}`)
+      Vue.set(this.widgets, id, HelloWorld.name)
+    },
+    onAddColoredCircleButtonClicked () {
+      const id = `${new Date().getTime()}`
+      // eslint-disable-next-line no-console
+      console.log(`Adding new widget ${ColoredCircle.name}, ID ${id}`)
+      Vue.set(this.widgets, id, ColoredCircle.name)
+    },
+    onWidgetActivatedEvent (event) {
+      // eslint-disable-next-line no-console
+      console.log(`Activated widget ${event.id}`)
+    },
+    onWidgetDeletedEvent (event) {
+      // eslint-disable-next-line no-console
+      console.log(`Deleted widget ${event.id}`)
+      Vue.delete(this.widgets, event.id)
     }
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,6 +24,15 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
     <button @click="addHelloWorldWidget">Add Hello World</button>
     <button @click="addColoredCircleWidget">Add Circle</button>
     <Lumino ref="lumino">
+      <!-- In this example we are adding two types of elements as tabs. The code
+      of this view is using the component name plus a random number for the component
+      ID, and the component name as the name to be displayed in the Lumino tab.
+
+      Props, events, slots are all supported. The elements will be added to the
+      default slot, which is wrapped in a `<div v-show=false>`. Later some
+      code attaches the Vue component `$el` under the Lumino widget, and via
+      events tries to keep everything in-sync (fingers-crossed).
+      -->
       <HelloWorld
         v-for="helloWorldWidget of this.helloWorldWidgets"
         :key="helloWorldWidget.id"
@@ -62,8 +71,11 @@ export default {
 
   data () {
     return {
+      // list of `HelloWorld` widgets
       helloWorldWidgets: [],
+      // list of `ColoredCircle` widgets
       coloredCircleWidgets: [],
+      // colors used in the `ColoredCircle` widget, we pick only one randomly
       colors: ['purple', 'green', 'blue', 'red']
     }
   },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -21,8 +21,12 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
      when the button is clicked) -->
 <template>
   <div>
-    <button @click="addHelloWorldWidget">Add Hello World</button>
-    <button @click="addColoredCircleWidget">Add Circle</button>
+    <button
+      @click="helloWorldWidgets.push(new Date().getTime())"
+      >Add Hello World</button>
+    <button
+      @click="coloredCircleWidgets.push(new Date().getTime())"
+      >Add Circle</button>
     <Lumino ref="lumino">
       <!-- In this example we are adding two types of elements as tabs. The code
       of this view is using the component name plus a random number for the component
@@ -35,11 +39,11 @@ NOTE: Used for example/documentation only. Not intended to be used by users of t
       -->
       <HelloWorld
         v-for="helloWorldWidget of this.helloWorldWidgets"
-        :key="helloWorldWidget.id"
+        :key="helloWorldWidget"
       ></HelloWorld>
       <ColoredCircle
         v-for="coloredCircleWidget of this.coloredCircleWidgets"
-        :key="coloredCircleWidget.id"
+        :key="coloredCircleWidget"
         :color="_getRandomColor()"
       ></ColoredCircle>
     </Lumino>
@@ -88,30 +92,14 @@ export default {
    */
   mounted () {
     this.$nextTick(() => {
-      this.addHelloWorldWidget()
+      this.helloWorldWidgets.push(new Date().getTime())
     })
   },
 
   /**
-   * Only methods implemented are the ones to handle the buttons being clicked.
+   * Example methods.
    */
   methods: {
-    /**
-     * Add a `HelloWorld` widget.
-     */
-    addHelloWorldWidget () {
-      const id = `${HelloWorld.name}-${Math.random()}`
-      const name = `${HelloWorld.name}`
-      this.$refs.lumino.addWidget(id, name)
-    },
-    /**
-     * Add a `ColoredCircle` widget.
-     */
-    addColoredCircleWidget () {
-      const id = `${ColoredCircle.name}-${Math.random()}`
-      const name = `${ColoredCircle.name}`
-      this.$refs.lumino.addWidget(id, name)
-    },
     /**
      * Get a random color to be used as prop for the `ColoredCircle` widget.
      * @returns {string} a random color member of `this.colors`


### PR DESCRIPTION
Uses the default slot hidden, and creates the DOM elements for Lumino.

Next step is to figure out a way to move the Vue component to under
the Lumino widget.`